### PR TITLE
修复大小写导致的linux系统下启动报错的问题

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -90,17 +90,17 @@ export default [
                   },
                   {
                     path: '/staff-admin/customer-growth/contact-way/create',
-                    component: './StaffAdmin/contactWay/create',
+                    component: './StaffAdmin/ContactWay/create',
                     authority: [BizContactWay_Full, BizContactWay_Read],
                   },
                   {
                     path: '/staff-admin/customer-growth/contact-way/edit',
-                    component: './StaffAdmin/contactWay/edit',
+                    component: './StaffAdmin/ContactWay/edit',
                     authority: [BizContactWay_Full, BizContactWay_Read],
                   },
                   {
                     path: '/staff-admin/customer-growth/contact-way/copy',
-                    component: './StaffAdmin/contactWay/copy',
+                    component: './StaffAdmin/ContactWay/copy',
                     authority: [BizContactWay_Full, BizContactWay_Read],
                   },
                   {

--- a/src/pages/StaffAdmin/Customer/detail.tsx
+++ b/src/pages/StaffAdmin/Customer/detail.tsx
@@ -33,12 +33,12 @@ import _ from "lodash";
 import type {StaffOption} from "@/pages/StaffAdmin/Components/Modals/StaffTreeSelectionModal";
 import type {SimpleStaffInterface} from "@/services/staff";
 import {QuerySimpleStaffs} from "@/services/staff";
-import TableInput from "@/pages/StaffAdmin/Customer/components/TableInput";
+import TableInput from "@/pages/StaffAdmin/Customer/Components/TableInput";
 import type {CustomerTag, CustomerTagGroupItem} from '@/pages/StaffAdmin/CustomerTag/data';
 import CustomerTagSelectionModal from "@/pages/StaffAdmin/Components/Modals/CustomerTagSelectionModal";
 import {QueryCustomerTagGroups} from "@/services/customer_tag_group";
-import InternalTagModal from "@/pages/StaffAdmin/Customer/components/InternalTagModal";
-import Events from './components/Events'
+import InternalTagModal from "@/pages/StaffAdmin/Customer/Components/InternalTagModal";
+import Events from './Components/Events'
 import {CustomerEvents, InternalTags} from "@/pages/StaffAdmin/Customer/data";
 
 export const basicInfo = {

--- a/src/pages/StaffAdmin/Role/Components/form.tsx
+++ b/src/pages/StaffAdmin/Role/Components/form.tsx
@@ -74,17 +74,17 @@ const menus = [
       },
       {
         path: '/staff-admin/customer-growth/contact-way/create',
-        component: './StaffAdmin/contactWay/create',
+        component: './StaffAdmin/ContactWay/create',
         authority: [BizContactWay_Full, BizContactWay_Read],
       },
       {
         path: '/staff-admin/customer-growth/contact-way/edit',
-        component: './StaffAdmin/contactWay/edit',
+        component: './StaffAdmin/ContactWay/edit',
         authority: [BizContactWay_Full, BizContactWay_Read],
       },
       {
         path: '/staff-admin/customer-growth/contact-way/copy',
-        component: './StaffAdmin/contactWay/copy',
+        component: './StaffAdmin/ContactWay/copy',
         authority: [BizContactWay_Full, BizContactWay_Read],
       },
       {


### PR DESCRIPTION
部分代码中路径大小写不一致，导致在linux下启动报找不到组件的错误
